### PR TITLE
Print help as part of default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ DC := $(shell which docker-compose)
 
 default:
 	@echo "You need to specify a subcommand."
+	@make help
 	@exit 1
 
 help:
@@ -15,6 +16,7 @@ help:
 	@echo "test          - run tests"
 	@echo "test-coverage - run tests and generate coverage report in cover/"
 	@echo "docs          - generate Sphinx HTML documentation, including API docs"
+	@echo "help          - print this menu"
 
 # Dev configuration steps
 .docker-build:


### PR DESCRIPTION
Every time I run Make I'm greeted with the semihelpful reminder that I need to specify a subcommand. Then I have to go look in the make file to determine which commands are acceptable.

This prints the help command as part of the default message, and adds a documentation line about the help subcommand.